### PR TITLE
Fix/prod build

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Frontend app with **hot reload / React / cssnext**.
 ```console
 $ git clone https://github.com/MoOx/frontend-hot-starterkit
 $ cd frontend-hot-starterkit
-$ npm i
+$ npm install
 ```
 
 ## Start & watch
@@ -37,10 +37,10 @@ $ npm install
 
 **Note:** Unix user can just link the `git-hooks/post-merge`:
 
-## Enable git hooks (unix only :/)
+## Enable git hooks
 
 ```console
-$ npm run create-hook-symlinks
+$ git-hooks/create-hook-symlinks
 ```
 
 ### `post-merge` (≃ `npm install`)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jscs": "jsxcs .",
     "eslint": "eslint . --ext=.js --ext=.jsx",
     "lint": "npm run --silent eslint && npm run --silent jscs",
-    "build": "webpack",
+    "build": "webpack -p",
     "server": "node scripts/server",
     "build-test": "node scripts/build-test",
     "pretest": "npm run lint --silent && npm run --silent build-test",


### PR DESCRIPTION
added `-p` to webpack command when `npm run dist` 
this will create a production ready bundle (~150Ko)

Replace `npm i` by `npm install` for better coherence with other command in the readme.

Updated the git hooks section since it works in windows for users having msygit or any bash like env.
